### PR TITLE
Fix attach_eth_if function

### DIFF
--- a/src/run_openwrt.sh
+++ b/src/run_openwrt.sh
@@ -55,6 +55,7 @@ attach_eth_if () {
   QEMU_IF_MAC=${QEMU_MAC_OUI}${MAC:8} # Replaces the 8 first characters of the original MAC
 
   # Deacticate host interface
+  # Ensure the interface is down to reliably change the MAC address without issues
   ip link set $CONTAINER_IF down
 
   # Change MAC address of new interface

--- a/src/run_openwrt.sh
+++ b/src/run_openwrt.sh
@@ -55,13 +55,13 @@ attach_eth_if () {
   QEMU_IF_MAC=${QEMU_MAC_OUI}${MAC:8} # Replaces the 8 first characters of the original MAC
 
   # Deacticate host interface
-  ip link set $HOST_IF down
+  ip link set $CONTAINER_IF down
 
   # Change MAC address of new interface
   ip link set $QEMU_IF address $QEMU_IF_MAC
 
   # Reactivate interfaces
-  ip link set $QEMU_IF up && ip link set $HOST_IF up
+  ip link set $QEMU_IF up && ip link set $CONTAINER_IF up
 }
 
 # Create veth pairs between host system and Docker container

--- a/src/run_openwrt.sh
+++ b/src/run_openwrt.sh
@@ -54,9 +54,14 @@ attach_eth_if () {
   read MAC </sys/class/net/$CONTAINER_IF/address
   QEMU_IF_MAC=${QEMU_MAC_OUI}${MAC:8} # Replaces the 8 first characters of the original MAC
 
-  # Active new interface
-  ip link set $QEMU_IF address $QEMU_IF_MAC up
-  #ip link set $QEMU_IF up
+  # Deacticate host interface
+  ip link set $HOST_IF down
+
+  # Change MAC address of new interface
+  ip link set $QEMU_IF address $QEMU_IF_MAC
+
+  # Reactivate interfaces
+  ip link set $QEMU_IF up && ip link set $HOST_IF up
 }
 
 # Create veth pairs between host system and Docker container


### PR DESCRIPTION
With the new version, it is not possible to attach a physical interface on the u-control to OpenWrt.

![image](https://github.com/user-attachments/assets/3f0ba89e-7104-4871-bdaa-e0143deedfd6)

I’ve identified the issue, built a fix, and tested it using a Docker container directly on the u-control with the following docker run command:

```
docker run --name openwrt-u-os \
    --env LAN_IF=veth \
    --env WAN_IF=eth-x4 \
    --env USB_1=2c7c:0801 \
    --env CPU_COUNT=2 \
    --env RAM_COUNT=512 \
    --env IS_U_OS_APP=y \
    --env FORWARD_LUCI=true \
    --privileged \
    --device /dev/kvm \
    --device /dev \
    --device-cgroup-rule="c *:* rwm" \
    --cap-add NET_ADMIN \
    --pid host \
    -p 8006:8006 \
    -v /dev:/dev/ \
    -v data:/storage/ \
    --add-host host.docker.internal:host-gateway \
    --restart no \
    openwrt-docker-fix
```

I successfully got the container running on the u-control and LuCI operational again. Profinet also works as exprected. However, I couldn’t access the noVNC website on port 8006. This is likely due to an issue in my docker run command rather than the fix itself.