### PR TITLE
Align disk images on 4k sectors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,9 @@ RUN echo "Building for platform '$TARGETPLATFORM'" \
     && wget $OPENWRT_IMAGE -O /var/vm/squashfs-combined-${OPENWRT_VERSION}.img.gz \
     && gzip -d /var/vm/squashfs-combined-${OPENWRT_VERSION}.img.gz \
     \
+    # 4k align the openwrt image so qemu doesn't complain about resize errors \
+    && dd if=/dev/zero of="/var/vm/squashfs-combined-${OPENWRT_VERSION}.img" seek="128" obs=1M count=0 \
+    \
     # Each CPU architecture needs a different SSH port to make a possible to make a parallel build \
     && SSH_PORT=1022 \
     \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
       #    Follow: https://openwrt.org/docs/guide-user/advanced/expand_root
       #  * If you want to resize the OpenWrt after the container first time run
       #    Follow: https://github.com/AlbrechtL/openwrt-docker/issues/34#issuecomment-2795886248
-      # Value: Size im MB (minimal 512)
+      # Value: Size in MiB (minimal 512)
       # If unset -> no resize (OpenWrt default image size)
       #IMAGE_SIZE_ON_INIT: "512"
 

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -20,6 +20,6 @@ trap 'error "Status $? while: $BASH_COMMAND (line $LINENO/$BASH_LINENO)"' ERR
 : "${LUCI_WEB_BUTTON_JSON:=""}"   # Adapt the "OpenWrt LuCI web interface" button to your needs.
 : "${OPENWRT_AFTER_BOOT_CMD:=""}" # User command or script to run after OpenWrt is booted
 : "${DISABLE_OPENWRT_AUTO_UPGRADE:=""}"  # Disables the OpenWrt upgrade check every container startup
-: "${IMAGE_SIZE_ON_INIT:=""}"  # New OpenWrt disk image size
+: "${IMAGE_SIZE_ON_INIT:=""}"  # New OpenWrt disk image size in MiB
 : "${IS_U_OS_APP:=""}"    # By default this container is not a u-OS app
 : "${DEBUG:=""}"          # Disable debugging

--- a/src/install_openwrt_rootfs.sh
+++ b/src/install_openwrt_rootfs.sh
@@ -20,8 +20,9 @@ if [[ ($DISABLE_OPENWRT_AUTO_UPGRADE != "true") ||  (! -f /storage/current_versi
       if [[ -n "$IMAGE_SIZE_ON_INIT" ]]; then
           # Check if IMAGE_SIZE_ON_INIT is greater than 511
           if [[ "$IMAGE_SIZE_ON_INIT" -gt 511 ]]; then
-              info "Resize OpenWrt to $IMAGE_SIZE_ON_INIT MB"
-              dd if=/dev/zero of="/storage/squashfs-combined-${OPENWRT_IMAGE_ID}.img" seek="$IMAGE_SIZE_ON_INIT" obs=1MB count=0
+              info "Resize OpenWrt to $IMAGE_SIZE_ON_INIT MiB"
+              ## M (ie 1024x1024) aligns the image on 4k blocks and prevents qemu "Cannot get 'write' permission without 'resize'" errors
+              dd if=/dev/zero of="/storage/squashfs-combined-${OPENWRT_IMAGE_ID}.img" seek="$IMAGE_SIZE_ON_INIT" obs=1M count=0
           else
               error "Error: IMAGE_SIZE_ON_INIT must be greater than 511."
               rm /storage/squashfs-combined-${OPENWRT_IMAGE_ID}.img


### PR DESCRIPTION
The upstream openwrt images are not aligned on 4k sector boundaries. This leads to qemu throwing errors about lacking the resize permission because the image is opened with O_DIRECT which expects the image to be aligned and will try to align it automatically if it doesn't. But that automatic alignment requires the RESIZE permission in qemu.

During docker image builds we resize the upstream image by a couple MB and specify 'M' to dd instead of 'MB'. The difference is documented in the dd man page but boils down to the difference of 1000*1000 (MB) versus 1024*1024 (M). By using 'M' we ensure an image aligned on 4096 bytes

Additionally this commit modifies the IMAGE_SIZE_ON_INIT code so it also uses 'M' and generates 4k aligned images as well.

Testing: Built a docker image with my changes and ran it